### PR TITLE
DT-9731 (DT-9881): add datafy_volume Terraform resource

### DIFF
--- a/internal/datafy/client.go
+++ b/internal/datafy/client.go
@@ -30,7 +30,7 @@ func NewClient(token, endpoint string) *Client {
 	}
 }
 
-func (c *Client) callAPI(ctx context.Context, method, path string, body map[string]interface{}) (*http.Response, error) {
+func (c *Client) callAPI(ctx context.Context, method, path string, body any) (*http.Response, error) {
 	var reqBody io.Reader
 	if body != nil {
 		jsonData, err := json.Marshal(body)

--- a/internal/datafy/volume.go
+++ b/internal/datafy/volume.go
@@ -1,0 +1,105 @@
+package datafy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type CreateVolumeRequest struct {
+	AvailabilityZone string
+	DiskSize         int64
+	VolumeIops       int64
+	VolumeThroughput int64
+	Encrypted        bool
+	KmsKeyId         string
+	Tags             map[string]string
+}
+
+type CreateVolumeResponse struct {
+	VolumeId     string `json:"volumeId"`
+	VolumeSizeGB int32  `json:"volumeSizeGB"`
+}
+
+type volumeTag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type Volume struct {
+	EbsId            string      `json:"volumeId"`
+	AvailabilityZone string      `json:"availabilityZone"`
+	DiskSize         uint64      `json:"diskSize"`
+	Iops             uint32      `json:"iops"`
+	Throughput       uint32      `json:"throughput"`
+	Tags             []volumeTag `json:"tags"`
+}
+
+type getVolumesResponse struct {
+	Volumes []Volume `json:"volumes"`
+}
+
+func (c *Client) CreateVolume(ctx context.Context, req *CreateVolumeRequest) (*CreateVolumeResponse, error) {
+	props := map[string]interface{}{
+		"availabilityZone": req.AvailabilityZone,
+		"diskSize":         req.DiskSize,
+		"volumeIops":       req.VolumeIops,
+		"volumeThroughput": req.VolumeThroughput,
+		"encrypted":        req.Encrypted,
+		"kmsKeyId":         req.KmsKeyId,
+	}
+	if len(req.Tags) > 0 {
+		tags := make([]map[string]string, 0, len(req.Tags))
+		for k, v := range req.Tags {
+			tags = append(tags, map[string]string{"key": k, "value": v})
+		}
+		props["tags"] = tags
+	}
+	body := map[string]interface{}{"volumeProperties": props}
+	resp, err := c.callAPI(ctx, http.MethodPost, "/api/v1/volumes/create-datafied-volume", body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, toError(resp)
+	}
+	var result CreateVolumeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetVolume returns nil if the volume is not found.
+func (c *Client) GetVolume(ctx context.Context, volumeId string) (*Volume, error) {
+	resp, err := c.callAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/volumes/%s", volumeId), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, toError(resp)
+	}
+	var result getVolumesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	if len(result.Volumes) == 0 {
+		return nil, nil
+	}
+	return &result.Volumes[0], nil
+}
+
+func (c *Client) DeleteVolume(ctx context.Context, volumeId string) error {
+	resp, err := c.callAPI(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/volumes/%s", volumeId), nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return toError(resp)
+	}
+	return nil
+}

--- a/internal/datafy/volume.go
+++ b/internal/datafy/volume.go
@@ -18,8 +18,8 @@ type CreateVolumeRequest struct {
 }
 
 type CreateVolumeResponse struct {
-	VolumeId     string `json:"volumeId"`
-	VolumeSizeGB int32  `json:"volumeSizeGB"`
+	VolumeId        string   `json:"volumeId"`
+	TargetVolumeIds []string `json:"targetVolumeIds"`
 }
 
 type volumeTag struct {

--- a/internal/datafy/volume.go
+++ b/internal/datafy/volume.go
@@ -40,24 +40,33 @@ type getVolumesResponse struct {
 	Volumes []Volume `json:"volumes"`
 }
 
+type createVolumeBody struct {
+	VolumeProperties createVolumeProps `json:"volumeProperties"`
+}
+
+type createVolumeProps struct {
+	AvailabilityZone string      `json:"availabilityZone"`
+	DiskSize         int64       `json:"diskSize"`
+	VolumeIops       int64       `json:"volumeIops"`
+	VolumeThroughput int64       `json:"volumeThroughput"`
+	Encrypted        bool        `json:"encrypted"`
+	KmsKeyId         string      `json:"kmsKeyId,omitempty"`
+	Tags             []volumeTag `json:"tags,omitempty"`
+}
+
 func (c *Client) CreateVolume(ctx context.Context, req *CreateVolumeRequest) (*CreateVolumeResponse, error) {
-	props := map[string]interface{}{
-		"availabilityZone": req.AvailabilityZone,
-		"diskSize":         req.DiskSize,
-		"volumeIops":       req.VolumeIops,
-		"volumeThroughput": req.VolumeThroughput,
-		"encrypted":        req.Encrypted,
-		"kmsKeyId":         req.KmsKeyId,
+	props := createVolumeProps{
+		AvailabilityZone: req.AvailabilityZone,
+		DiskSize:         req.DiskSize,
+		VolumeIops:       req.VolumeIops,
+		VolumeThroughput: req.VolumeThroughput,
+		Encrypted:        req.Encrypted,
+		KmsKeyId:         req.KmsKeyId,
 	}
-	if len(req.Tags) > 0 {
-		tags := make([]map[string]string, 0, len(req.Tags))
-		for k, v := range req.Tags {
-			tags = append(tags, map[string]string{"key": k, "value": v})
-		}
-		props["tags"] = tags
+	for k, v := range req.Tags {
+		props.Tags = append(props.Tags, volumeTag{Key: k, Value: v})
 	}
-	body := map[string]interface{}{"volumeProperties": props}
-	resp, err := c.callAPI(ctx, http.MethodPost, "/api/v1/volumes/create-datafied-volume", body)
+	resp, err := c.callAPI(ctx, http.MethodPost, "/api/v1/volumes/create-datafied-volume", createVolumeBody{VolumeProperties: props})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/datafy-io/terraform-provider-datafy/internal/service/autoscaling_rule"
 	"github.com/datafy-io/terraform-provider-datafy/internal/service/rolearn"
 	"github.com/datafy-io/terraform-provider-datafy/internal/service/token"
+	"github.com/datafy-io/terraform-provider-datafy/internal/service/volume"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -107,6 +108,7 @@ func (p *DatafyProvider) Resources(ctx context.Context) []func() resource.Resour
 		rolearn.NewResource,
 		token.NewResource,
 		autoscaling_rule.NewResource,
+		volume.NewResource,
 	}
 }
 

--- a/internal/service/volume/volume_resource.go
+++ b/internal/service/volume/volume_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -42,6 +43,7 @@ type ResourceModel struct {
 	KmsKeyId         types.String `tfsdk:"kms_key_id"`
 	Tags             types.Map    `tfsdk:"tags"`
 	VolumeSizeGB     types.Int64  `tfsdk:"volume_size_gb"`
+	TargetVolumeIds  types.List   `tfsdk:"target_volume_ids"`
 }
 
 func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -123,6 +125,14 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
+			"target_volume_ids": schema.ListAttribute{
+				Description: "EBS volume IDs of the two underlying target volumes.",
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }
@@ -171,8 +181,18 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
+	targetIds := make([]attr.Value, len(result.TargetVolumeIds))
+	for i, id := range result.TargetVolumeIds {
+		targetIds[i] = types.StringValue(id)
+	}
+	targetList, diags := types.ListValue(types.StringType, targetIds)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	plan.Id = types.StringValue(result.VolumeId)
-	plan.VolumeSizeGB = types.Int64Value(int64(result.VolumeSizeGB))
+	plan.TargetVolumeIds = targetList
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/internal/service/volume/volume_resource.go
+++ b/internal/service/volume/volume_resource.go
@@ -1,0 +1,233 @@
+package volume
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/datafy-io/terraform-provider-datafy/internal/datafy"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.ResourceWithConfigure   = &Resource{}
+	_ resource.ResourceWithImportState = &Resource{}
+)
+
+func NewResource() resource.Resource {
+	return &Resource{}
+}
+
+type Resource struct {
+	client *datafy.Client
+}
+
+type ResourceModel struct {
+	Id               types.String `tfsdk:"id"`
+	AvailabilityZone types.String `tfsdk:"availability_zone"`
+	DiskSize         types.Int64  `tfsdk:"disk_size"`
+	VolumeIops       types.Int64  `tfsdk:"volume_iops"`
+	VolumeThroughput types.Int64  `tfsdk:"volume_throughput"`
+	Encrypted        types.Bool   `tfsdk:"encrypted"`
+	KmsKeyId         types.String `tfsdk:"kms_key_id"`
+	Tags             types.Map    `tfsdk:"tags"`
+	VolumeSizeGB     types.Int64  `tfsdk:"volume_size_gb"`
+}
+
+func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_volume"
+}
+
+func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provisions a Datafy native datafied volume: two blank gp3 EBS target volumes pre-tagged for Datafy agent initialization. The agent completes setup on first attach.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The synthesized EBS volume ID used as the logical source identifier.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"availability_zone": schema.StringAttribute{
+				Description: "AWS availability zone in which to create the volume (e.g. us-east-1a).",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"disk_size": schema.Int64Attribute{
+				Description: "Logical disk size in GiB presented to the OS.",
+				Required:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
+			},
+			"volume_iops": schema.Int64Attribute{
+				Description: "Provisioned IOPS for the underlying gp3 EBS volumes. Defaults to 3000.",
+				Optional:    true,
+				Computed:    true,
+				Default:     int64default.StaticInt64(3000),
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
+			},
+			"volume_throughput": schema.Int64Attribute{
+				Description: "Provisioned throughput in MiB/s for the underlying gp3 EBS volumes. Defaults to 125.",
+				Optional:    true,
+				Computed:    true,
+				Default:     int64default.StaticInt64(125),
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
+			},
+			"encrypted": schema.BoolAttribute{
+				Description: "Whether the EBS volumes are encrypted. Defaults to true.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"kms_key_id": schema.StringAttribute{
+				Description: "KMS key ID or ARN to use for volume encryption. Uses the default AWS-managed key if omitted.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"tags": schema.MapAttribute{
+				Description: "Key-value tags to apply to the EBS volumes.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.RequiresReplace(),
+				},
+			},
+			"volume_size_gb": schema.Int64Attribute{
+				Description: "Actual size in GiB of each underlying EBS target volume as provisioned.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*datafy.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *datafy.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tags := map[string]string{}
+	if !plan.Tags.IsNull() && !plan.Tags.IsUnknown() {
+		resp.Diagnostics.Append(plan.Tags.ElementsAs(ctx, &tags, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	result, err := r.client.CreateVolume(ctx, &datafy.CreateVolumeRequest{
+		AvailabilityZone: plan.AvailabilityZone.ValueString(),
+		DiskSize:         plan.DiskSize.ValueInt64(),
+		VolumeIops:       plan.VolumeIops.ValueInt64(),
+		VolumeThroughput: plan.VolumeThroughput.ValueInt64(),
+		Encrypted:        plan.Encrypted.ValueBool(),
+		KmsKeyId:         plan.KmsKeyId.ValueString(),
+		Tags:             tags,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating volume", "Could not create volume: "+err.Error())
+		return
+	}
+
+	plan.Id = types.StringValue(result.VolumeId)
+	plan.VolumeSizeGB = types.Int64Value(int64(result.VolumeSizeGB))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	vol, err := r.client.GetVolume(ctx, state.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading volume", "Could not read volume: "+err.Error())
+		return
+	}
+	if vol == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.AvailabilityZone = types.StringValue(vol.AvailabilityZone)
+	state.DiskSize = types.Int64Value(int64(vol.DiskSize >> 30))
+	state.VolumeIops = types.Int64Value(int64(vol.Iops))
+	state.VolumeThroughput = types.Int64Value(int64(vol.Throughput))
+
+	tagMap := make(map[string]attr.Value, len(vol.Tags))
+	for _, t := range vol.Tags {
+		tagMap[t.Key] = types.StringValue(t.Value)
+	}
+	tags, diags := types.MapValue(types.StringType, tagMap)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Tags = tags
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *Resource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+	// All fields are RequiresReplace; Update is never called.
+}
+
+func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.DeleteVolume(ctx, state.Id.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting volume", "Could not delete volume: "+err.Error())
+	}
+}
+
+func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/volume/volume_resource.go
+++ b/internal/service/volume/volume_resource.go
@@ -181,11 +181,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	targetIds := make([]attr.Value, len(result.TargetVolumeIds))
-	for i, id := range result.TargetVolumeIds {
-		targetIds[i] = types.StringValue(id)
-	}
-	targetList, diags := types.ListValue(types.StringType, targetIds)
+	targetList, diags := types.ListValueFrom(ctx, types.StringType, result.TargetVolumeIds)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
## Summary

- Adds `datafy_volume` resource wrapping `POST /api/v1/volumes/create-datafied-volume`
- Full CRUD lifecycle: Create → new endpoint, Read → `GET /api/v1/volumes/{id}`, Delete → `DELETE /api/v1/volumes/{id}`, Update → no-op (all fields are `RequiresReplace`)
- Schema fields: `availability_zone`, `disk_size`, `volume_iops` (default 3000), `volume_throughput` (default 125), `encrypted` (default true), `kms_key_id`, `tags`
- Computed outputs: `id` (synthesized source vol-id), `volume_size_gb`
- Drift detection on `availability_zone`, `disk_size`, `volume_iops`, `volume_throughput`, `tags`
- Import support via `terraform import datafy_volume.example <vol-id>`
- Empty `tags` omitted from request body rather than sent as `[]`

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` clean
- [ ] Manual: `terraform apply` provisions volume with correct tags in AWS console
- [ ] Manual: `terraform plan` after apply shows empty diff
- [ ] Manual: `terraform destroy` removes the volume
- [ ] Manual: `terraform import` followed by `terraform plan` shows no drift